### PR TITLE
Improving sliced Tensor types

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ assert Tensor[3, 2, 4](t)
 # This will match no matter the size of the second axis
 assert Tensor[3, :, 4](t)
 
-# This will match only tensors with size from 1 to 4 for the second axis
-assert Tensor[3, 1:5, 4](t)
+# This will match only tensors with size from 1 to 5 for the second axis
+assert Tensor[3, 1:6, 4](t)
+
+# This will match only tensors with size from 1, 3 or 5 for the second axis
+assert Tensor[3, 1:5:2, 4](t)
 
 batch = 64
 channels = 3

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ assert Tensor[3, 2, 4](t)
 # This will match no matter the size of the second axis
 assert Tensor[3, :, 4](t)
 
+# This will match only tensors with size from 1 to 4 for the second axis
+assert Tensor[3, 1:5, 4](t)
+
 batch = 64
 channels = 3
 h, w = 256, 512

--- a/tensor_type/tensor_type.py
+++ b/tensor_type/tensor_type.py
@@ -84,7 +84,9 @@ class _Tensor:
             if isinstance(type_dim, slice):
                 valid &= type_dim.start is None or real_dim >= type_dim.start       # check if within bounds ...
                 valid &= type_dim.stop is None  or real_dim < type_dim.stop         # excluding stop, as usual
-                valid &= type_dim.step is None  or real_dim % type_dim.step == 0    # within start:stop:step 
+                start = type_dim.start if type_dim.start is not None else 0
+                valid &= type_dim.step is None  or (real_dim - start) % type_dim.step == 0    
+                                                                                    # within start:stop:step 
             else:
                 valid &= real_dim == type_dim
 

--- a/tensor_type/tensor_type.py
+++ b/tensor_type/tensor_type.py
@@ -82,8 +82,11 @@ class _Tensor:
 
         for real_dim, type_dim in zip(x.shape, cls.type_shape):
             if isinstance(type_dim, slice):
-                continue
-            valid &= real_dim == type_dim
+                valid &= type_dim.start is None or real_dim >= type_dim.start       # check if within bounds ...
+                valid &= type_dim.stop is None  or real_dim < type_dim.stop         # excluding stop, as usual
+                valid &= type_dim.step is None  or real_dim % type_dim.step == 0    # within start:stop:step 
+            else:
+                valid &= real_dim == type_dim
 
         return valid
 


### PR DESCRIPTION
Hey there, amazing work! I'm actually confused this isn't more widely used. For my use case, I found the slicing to be an important feature, so I quickly added this, meaning you can now use the slicing to also restrict to ranges like e.g.
```
from tensor_type import Tensor
import torch

x = torch.ones(1,2,3,4)

assert Tensor[:,1:5,:,:](x)
assert not Tensor[:,1:5:2,:,:](x)
assert Tensor[:,:5:2,:,:](x)
```
How you like the changes?